### PR TITLE
template deployments to be able to use different image for prod/stg

### DIFF
--- a/openshift/deployment-fedmsg.yml.j2
+++ b/openshift/deployment-fedmsg.yml.j2
@@ -47,7 +47,7 @@ spec:
           secretName: packit-config
       containers:
         - name: packit-service-fedmsg
-          image: docker.io/usercont/packit-service:master
+          image: docker.io/usercont/packit-service:{{ deployment }}
           volumeMounts:
           - name: packit-ssh
             mountPath: /packit-ssh

--- a/openshift/deployment-worker.yml.j2
+++ b/openshift/deployment-worker.yml.j2
@@ -67,7 +67,7 @@ spec:
           claimName: packit-worker-pvc-2
       containers:
       - name: packit-worker-1
-        image: docker.io/usercont/packit-service:master
+        image: docker.io/usercont/packit-service:{{ deployment }}
         env:
           - name: APP
             value: packit_service.worker.tasks
@@ -92,7 +92,7 @@ spec:
             memory: "512Mi"
             cpu: "800m"
       - name: packit-worker-2
-        image: docker.io/usercont/packit-service:master
+        image: docker.io/usercont/packit-service:{{ deployment }}
         env:
           - name: APP
             value: packit_service.worker.tasks

--- a/openshift/deployment-worker.yml.j2
+++ b/openshift/deployment-worker.yml.j2
@@ -116,25 +116,3 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "800m"
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: packit-worker-pvc-1
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: packit-worker-pvc-2
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi

--- a/openshift/deployment.yml.j2
+++ b/openshift/deployment.yml.j2
@@ -47,7 +47,7 @@ spec:
           name: httpd-conf
       containers:
         - name: packit-service
-          image: docker.io/usercont/packit-service:master
+          image: docker.io/usercont/packit-service:{{ deployment }}
           ports:
           - containerPort: 8443
             protocol: TCP

--- a/openshift/pvc-worker.yml
+++ b/openshift/pvc-worker.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: packit-worker-pvc-1
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: packit-worker-pvc-2
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -87,6 +87,7 @@
         api_key: "{{ api_key }}"
         verify_ssl: "{{ verify_ssl }}"
       loop:
+        - ../openshift/pvc-worker.yml
         - ../openshift/redis.yml
         - ../openshift/service.yml
 

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -76,6 +76,7 @@
         verify_ssl: "{{ verify_ssl }}"
       loop:
         - "{{ lookup('template', '../openshift/deployment.yml.j2') | from_yaml }}"
+        - "{{ lookup('template', '../openshift/deployment-worker.yml.j2') | from_yaml }}"
 
     - name: Deploy resource configs (no need to process them)
       # https://docs.ansible.com/k8s_module.html
@@ -88,7 +89,6 @@
       loop:
         - ../openshift/redis.yml
         - ../openshift/service.yml
-        - ../openshift/deployment-worker.yml
 
     - name: Deploy redis-commander.
       k8s:
@@ -111,7 +111,7 @@
     - name: Deploy fedmsg listener
       k8s:
         namespace: "{{ project }}"
-        src: ../openshift/deployment-fedmsg.yml
+        definition: "{{ lookup('template', '../openshift/deployment-fedmsg.yml.j2') | from_yaml }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
         verify_ssl: "{{ verify_ssl }}"


### PR DESCRIPTION
I have added two new hooks:

- branch `master` -> `docker.io/usercont/packit-service:stg`
- branch `stable` -> `docker.io/usercont/packit-service:prod`

https://cloud.docker.com/u/usercont/repository/docker/usercont/packit-service/builds