### PR TITLE
keep verify_ssl as it works for both 2.7 and 2.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: send-release-event deploy cleanup zuul-secrets get-certs
 
+ANSIBLE_PYTHON := /usr/bin/python3
 CONT_HOME := /opt/app-root/src
-AP := ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=/usr/bin/python3
+AP := ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=$(ANSIBLE_PYTHON)
 
 # use route when doing this on a remote openshift cluster
 send-release-event:

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -57,7 +57,7 @@
         definition: "{{ item }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ verify_ssl }}"
+        verify_ssl: "{{ validate_certs }}"
       loop:
         - "{{ lookup('template', '../openshift/secret-packit-ssh.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/secret-packit-secrets.yml.j2') | from_yaml }}"
@@ -114,7 +114,7 @@
         definition: "{{ item }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ verify_ssl }}"
+        verify_ssl: "{{ validate_certs }}"
       loop:
         - "{{ lookup('template', '../openshift/deployment.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/deployment-worker.yml.j2') | from_yaml }}"
@@ -126,7 +126,7 @@
         src: "{{ item }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ verify_ssl }}"
+        verify_ssl: "{{ validate_certs }}"
       loop:
         - ../openshift/redis.yml
         - ../openshift/service.yml
@@ -137,7 +137,7 @@
         src: ../openshift/redis-commander.yml
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ verify_ssl }}"
+        verify_ssl: "{{ validate_certs }}"
       when: not without_redis_commander
 
     - name: Deploy flower
@@ -146,7 +146,7 @@
         src: ../openshift/flower.yml
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ verify_ssl }}"
+        verify_ssl: "{{ validate_certs }}"
       when: not without_flower
 
     - name: Deploy fedmsg listener
@@ -155,7 +155,7 @@
         definition: "{{ lookup('template', '../openshift/deployment-fedmsg.yml.j2') | from_yaml }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ verify_ssl }}"
+        verify_ssl: "{{ validate_certs }}"
       when: not without_fedmsg
 
     - name: Set up the sandbox namespace

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -57,7 +57,7 @@
         definition: "{{ item }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ validate_certs }}"
+        verify_ssl: "{{ validate_certs }}" # 2.7 compatibility
       loop:
         - "{{ lookup('template', '../openshift/secret-packit-ssh.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/secret-packit-secrets.yml.j2') | from_yaml }}"
@@ -114,7 +114,7 @@
         definition: "{{ item }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ validate_certs }}"
+        verify_ssl: "{{ validate_certs }}" # 2.7 compatibility
       loop:
         - "{{ lookup('template', '../openshift/deployment.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/deployment-worker.yml.j2') | from_yaml }}"
@@ -126,7 +126,7 @@
         src: "{{ item }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ validate_certs }}"
+        verify_ssl: "{{ validate_certs }}" # 2.7 compatibility
       loop:
         - ../openshift/redis.yml
         - ../openshift/service.yml
@@ -137,7 +137,7 @@
         src: ../openshift/redis-commander.yml
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ validate_certs }}"
+        verify_ssl: "{{ validate_certs }}" # 2.7 compatibility
       when: not without_redis_commander
 
     - name: Deploy flower
@@ -146,7 +146,7 @@
         src: ../openshift/flower.yml
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ validate_certs }}"
+        verify_ssl: "{{ validate_certs }}" # 2.7 compatibility
       when: not without_flower
 
     - name: Deploy fedmsg listener
@@ -155,7 +155,7 @@
         definition: "{{ lookup('template', '../openshift/deployment-fedmsg.yml.j2') | from_yaml }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        verify_ssl: "{{ validate_certs }}"
+        verify_ssl: "{{ validate_certs }}" # 2.7 compatibility
       when: not without_fedmsg
 
     - name: Set up the sandbox namespace

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -57,8 +57,7 @@
         definition: "{{ item }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        validate_certs: "{{ validate_certs }}"
-        verify_ssl: "{{ validate_certs }}"  # 2.7 compat
+        verify_ssl: "{{ verify_ssl }}"
       loop:
         - "{{ lookup('template', '../openshift/secret-packit-ssh.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/secret-packit-secrets.yml.j2') | from_yaml }}"
@@ -115,8 +114,7 @@
         definition: "{{ item }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        validate_certs: "{{ validate_certs }}"
-        verify_ssl: "{{ validate_certs }}"  # 2.7 compat
+        verify_ssl: "{{ verify_ssl }}"
       loop:
         - "{{ lookup('template', '../openshift/deployment.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/deployment-worker.yml.j2') | from_yaml }}"
@@ -128,8 +126,7 @@
         src: "{{ item }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        validate_certs: "{{ validate_certs }}"
-        verify_ssl: "{{ validate_certs }}"  # 2.7 compat
+        verify_ssl: "{{ verify_ssl }}"
       loop:
         - ../openshift/redis.yml
         - ../openshift/service.yml
@@ -140,8 +137,7 @@
         src: ../openshift/redis-commander.yml
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        validate_certs: "{{ validate_certs }}"
-        verify_ssl: "{{ validate_certs }}"  # 2.7 compat
+        verify_ssl: "{{ verify_ssl }}"
       when: not without_redis_commander
 
     - name: Deploy flower
@@ -150,8 +146,7 @@
         src: ../openshift/flower.yml
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        validate_certs: "{{ validate_certs }}"
-        verify_ssl: "{{ validate_certs }}"  # 2.7 compat
+        verify_ssl: "{{ verify_ssl }}"
       when: not without_flower
 
     - name: Deploy fedmsg listener
@@ -160,8 +155,7 @@
         definition: "{{ lookup('template', '../openshift/deployment-fedmsg.yml.j2') | from_yaml }}"
         host: "{{ host }}"
         api_key: "{{ api_key }}"
-        validate_certs: "{{ validate_certs }}"
-        verify_ssl: "{{ validate_certs }}"  # 2.7 compat
+        verify_ssl: "{{ verify_ssl }}"
       when: not without_fedmsg
 
     - name: Set up the sandbox namespace


### PR DESCRIPTION
According to the official [docs](https://docs.ansible.com/ansible/latest/modules/k8s_module.html) `verify_ssl` is an alias for the `validate_certs`.