### PR TITLE
[httpd-conf] remove 'WSGIPythonPath /src'

### DIFF
--- a/openshift/cmap-packit-httpd-conf.yml.j2
+++ b/openshift/cmap-packit-httpd-conf.yml.j2
@@ -30,7 +30,7 @@
       # FIXME: if we load this from a file, ansible interprets it as yaml
       #        this is why the httpd config file is inlined here
       #        feel free to fix it
-      WSGIPythonPath /src
+
       LogLevel info
       LogLevel wsgi:debug
       ErrorLog /dev/stderr


### PR DESCRIPTION
I spent whole hour debugging where the heck is `httpd` reading (wsgi script, i.e. packit-service) sources from and realized it's not `/usr/local/lib/python3.7/site-packages/packit_service`
into which I was volume mounting my current code,
but from `/src/` where the original sources were still stored.