### PR TITLE
More consistent CD

### DIFF
--- a/haxxx/Dockerfile
+++ b/haxxx/Dockerfile
@@ -5,4 +5,4 @@ RUN dnf install -y origin-clients && \
 
 COPY import-images.sh /usr/bin/
 
-CMD ["/usr/bin/import-images.sh"]
+CMD ["bash", "/usr/bin/import-images.sh"]

--- a/haxxx/README.md
+++ b/haxxx/README.md
@@ -1,11 +1,16 @@
-## Work-around for Openshift Online not periodically updating ImageStreams
+## Periodically updating ImageStreams
 
-OpenShift Online (where we currently run Packit Service) seems to have
-turned off periodical updates from image registry to ImageStream
-(even we explicitly [request them](https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/builds_and_image_streams.html#image-stream-mappings-working-periodic)).
+OpenShift Online seems to have turned off periodical updates from image registry
+to ImageStream (even we explicitly [request them](https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/builds_and_image_streams.html#image-stream-mappings-working-periodic)).
 
-[job-import-images.yml](./job-import-images.yml) - CronJob to periodically import images metadata into image streams. We use this on `stg`, see `oc describe cronjob.batch/import-images`.
-There's [imageimporter](https://admin-console.pro-eu-west-1.openshift.com/k8s/ns/packit-stg/serviceaccounts/importimager) [service account](https://docs.openshift.com/container-platform/3.11/dev_guide/service_accounts.html) with `registry-editor` [role](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_rbac.html) role added.
+As a work-around, there's a CronJob to periodically import images metadata into image streams.
+See [job-import-images.yml](./job-import-images.yml) and `oc describe cronjob.batch/import-images`.
+The job uses [imageimporter@stg](https://admin-console.pro-eu-west-1.openshift.com/k8s/ns/packit-stg/serviceaccounts/importimager) or [imageimporter@prod](https://admin-console.pro-eu-west-1.openshift.com/k8s/ns/packit-prod/serviceaccounts/importimager) [service account](https://docs.openshift.com/container-platform/3.11/dev_guide/service_accounts.html) with `registry-editor` [role](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_rbac.html) role added.
+If you ever needed to re-create it, just do:
+```bash
+$ oc create serviceaccount imageimporter
+$ oc policy add-role-to-user registry-editor -z importimager
+```
 
 [Dockerfile](./Dockerfile) - image used by the job
 

--- a/haxxx/import-images.sh
+++ b/haxxx/import-images.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-oc login https://api.pro-eu-west-1.openshift.com --token="${TOKEN}" --insecure-skip-tls-verify
+oc login "${HOST}" --token="${TOKEN}" --insecure-skip-tls-verify
 
 set -x
 

--- a/haxxx/job-import-images.yml
+++ b/haxxx/job-import-images.yml
@@ -3,8 +3,11 @@ kind: CronJob
 metadata:
   name: import-images
 spec:
-  # Run every 30min
-  schedule: "*/30 * * * *"
+  # https://crontab.guru
+  # STG: Once every hour (at minute 0)
+  schedule: "0 * * * *"
+  # PROD: At 02:00 on Monday
+  # schedule: "0 2 * * 1"
   jobTemplate:
     spec:
       template:
@@ -15,14 +18,19 @@ spec:
             env:
             - name: KUBECONFIG
               value: /tmp/.kube/config
+            - name: HOST
+              value: https://api.pro-eu-west-1.openshift.com
             - name: DEPLOYMENT
               value: stg
+              # PROD
+              # value: prod
             - name: TOKEN
               valueFrom:
                 secretKeyRef:
                   name: importimager-token-cbw75
+                  # PROD
+                  # name: importimager-token-gl9g9
                   key: token
-            command: ["bash", "/usr/bin/import-images.sh"]
             resources:
               requests:
                 memory: "64Mi"

--- a/openshift/imagestream-fedmsg.yml.j2
+++ b/openshift/imagestream-fedmsg.yml.j2
@@ -32,8 +32,9 @@ spec:
         kind: DockerImage
         name: {{ image_fedmsg }}
       importPolicy:
-        # periodically query registry to synchronize tag and image metadata
-        scheduled: {{ continuous_deployment }}
+        # Periodically query registry to synchronize tag and image metadata.
+        # DOES NOT WORK on Openshift Online.
+        scheduled: true
   lookupPolicy:
     # allows all resources pointing to this image stream to use it in the image field
     local: true

--- a/openshift/imagestream-worker.yml.j2
+++ b/openshift/imagestream-worker.yml.j2
@@ -32,8 +32,9 @@ spec:
         kind: DockerImage
         name: {{ image_worker }}:{{ deployment }}
       importPolicy:
-        # periodically query registry to synchronize tag and image metadata
-        scheduled: {{ continuous_deployment }}
+        # Periodically query registry to synchronize tag and image metadata.
+        # DOES NOT WORK on Openshift Online.
+        scheduled: true
   lookupPolicy:
     # allows all resources pointing to this image stream to use it in the image field
     local: true

--- a/openshift/imagestream.yml.j2
+++ b/openshift/imagestream.yml.j2
@@ -32,8 +32,9 @@ spec:
         kind: DockerImage
         name: {{ image }}:{{ deployment }}
       importPolicy:
-        # periodically query registry to synchronize tag and image metadata
-        scheduled: {{ continuous_deployment }}
+        # Periodically query registry to synchronize tag and image metadata.
+        # DOES NOT WORK on Openshift Online.
+        scheduled: true
   lookupPolicy:
     # allows all resources pointing to this image stream to use it in the image field
     local: true

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -35,7 +35,6 @@
     image_fedmsg: "usercont/packit-service-fedmsg"
     worker_replicas: 2
     path_to_secrets: "../secrets"
-    continuous_deployment: false
   tasks:
     - name: include variables
       include_vars: ../vars/{{ deployment }}.yml

--- a/vars/template.yml
+++ b/vars/template.yml
@@ -66,7 +66,3 @@ without_flower: false
 
 # Path to secrets (in case you don't have it in the root of this project)
 # path_to_secrets: /secrets
-
-# For prod you want false (default) - so you can re-deploy whenever you're ready
-# For stg/dev you want true - to have Continuous Deployment
-# continuous_deployment: true


### PR DESCRIPTION
* remove `continuous_deployment` env. var. - always set `scheduled: true` (it's ignored by OS Online anyway)
* add PROD values (even commented out) to job definition - so that we use it on PROD too
* much better docs