### PR TITLE
[Image streams] set 'importPolicy:scheduled' conditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ We use [ImageStreams](https://docs.openshift.com/container-platform/3.11/archite
 
 `Image registry` -> [1] -> `ImageStream` -> [2] -> `DeploymentConfig`/`StatefulSet`
 
-[1] automatic ([example](https://github.com/packit-service/deployment/blob/master/openshift/imagestream.yml.j2#L37)).
-OpenShift Online has this turned off.
+[1] set to automatic ([here](https://github.com/packit-service/deployment/blob/master/openshift/imagestream.yml.j2#L36)), however OpenShift Online has this turned off.
 We run a [CronJob](https://github.com/packit-service/deployment/blob/master/haxxx/job-import-images.yml) to work-around this.
 More info [here](./haxxx/README.md).
 It runs (i.e. imports newer images and re-deploys them)

--- a/openshift/imagestream-fedmsg.yml.j2
+++ b/openshift/imagestream-fedmsg.yml.j2
@@ -33,8 +33,7 @@ spec:
         name: {{ image_fedmsg }}
       importPolicy:
         # Periodically query registry to synchronize tag and image metadata.
-        # DOES NOT WORK on Openshift Online.
-        scheduled: true
+        scheduled: {{ auto_import_images }}
   lookupPolicy:
     # allows all resources pointing to this image stream to use it in the image field
     local: true

--- a/openshift/imagestream-worker.yml.j2
+++ b/openshift/imagestream-worker.yml.j2
@@ -33,8 +33,7 @@ spec:
         name: {{ image_worker }}:{{ deployment }}
       importPolicy:
         # Periodically query registry to synchronize tag and image metadata.
-        # DOES NOT WORK on Openshift Online.
-        scheduled: true
+        scheduled: {{ auto_import_images }}
   lookupPolicy:
     # allows all resources pointing to this image stream to use it in the image field
     local: true

--- a/openshift/imagestream.yml.j2
+++ b/openshift/imagestream.yml.j2
@@ -33,8 +33,7 @@ spec:
         name: {{ image }}:{{ deployment }}
       importPolicy:
         # Periodically query registry to synchronize tag and image metadata.
-        # DOES NOT WORK on Openshift Online.
-        scheduled: true
+        scheduled: {{ auto_import_images }}
   lookupPolicy:
     # allows all resources pointing to this image stream to use it in the image field
     local: true

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -35,6 +35,8 @@
     image_fedmsg: "usercont/packit-service-fedmsg"
     worker_replicas: 2
     path_to_secrets: "../secrets"
+    # to be used in Image streams as importPolicy:scheduled value
+    auto_import_images: "{{(deployment != 'prod')}}"
   tasks:
     - name: include variables
       include_vars: ../vars/{{ deployment }}.yml


### PR DESCRIPTION
to `false` on `prod` and `true` otherwise.

This doesn't change anything at the moment since these imports don't work on Online anyway.
But will be needed once we move elsewhere.
