### PR TITLE
Remove jinja2 templating from when-conditional

### DIFF
--- a/playbooks/cleanup.yml
+++ b/playbooks/cleanup.yml
@@ -42,4 +42,4 @@
 
     - name: oc delete all
       command: oc delete all,cm,pvc --all
-      when: '{{ deployment }} != "prod"'
+      when: deployment != "prod"


### PR DESCRIPTION
A variable evaluates just fine in a when-conditional, there is no need
for templating.

Removing this also fixes the following error:

```
The error was: error while evaluating conditional ({{ deployment }} !=
\"prod\"): 'dev' is undefined ...
```

when `DEPLOYMENT=dev`.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>