### PR TITLE
Enable HTTP authentication for redis Commander

### DIFF
--- a/openshift/redis-commander.yml
+++ b/openshift/redis-commander.yml
@@ -44,6 +44,16 @@ spec:
               value: redis
             - name: REDIS_PORT
               value: "6379"
+            - name: HTTP_USER
+              valueFrom:
+                secretKeyRef:
+                  key: redis-commander-user
+                  name: redis-commander-secret
+            - name: HTTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: redis-commander-password
+                  name: redis-commander-secret
           ports:
             - containerPort: 8081
           resources:
@@ -79,3 +89,6 @@ spec:
   to:
     kind: Service
     name: redis-commander
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: None

--- a/openshift/secret-redis-commander.yml.j2
+++ b/openshift/secret-redis-commander.yml.j2
@@ -1,0 +1,31 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-commander-secret
+type: Opaque
+data:
+  redis-commander-user: "{{ redis_commander_user | b64encode }}"
+  redis-commander-password: "{{ redis_commander_password | b64encode }}"

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -68,6 +68,7 @@
         - "{{ lookup('template', '../openshift/secret-packit-config.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/secret-sentry.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/secret-postgres.yml.j2') | from_yaml }}"
+        - "{{ lookup('template', '../openshift/secret-redis-commander.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/cmap-packit-httpd-conf.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/route.packit.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/sandbox-namespace.yml.j2') | from_yaml }}"

--- a/secrets/template/extra-vars.yml
+++ b/secrets/template/extra-vars.yml
@@ -1,3 +1,5 @@
 postgres_user: <user>
 postgres_password: <passwd>
 postgres_database_name: <db name>
+redis_commander_user: <user>
+redis_commander_password: <passwd>


### PR DESCRIPTION
Also: enforce HTTPS for the web console.

redis Commander docs:
- https://github.com/joeferner/redis-commander/blob/master/docs/configuration.md#41-authentication-configuration-for-http-server
- https://github.com/joeferner/redis-commander#environment-variables

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>