### PR TITLE
Fully define images in vars

### DIFF
--- a/openshift/imagestream-worker.yml.j2
+++ b/openshift/imagestream-worker.yml.j2
@@ -30,7 +30,7 @@ spec:
     - name: {{ deployment }}
       from:
         kind: DockerImage
-        name: {{ image_worker }}:{{ deployment }}
+        name: {{ image_worker }}
       importPolicy:
         # Periodically query registry to synchronize tag and image metadata.
         scheduled: {{ auto_import_images }}

--- a/openshift/imagestream.yml.j2
+++ b/openshift/imagestream.yml.j2
@@ -30,7 +30,7 @@ spec:
     - name: {{ deployment }}
       from:
         kind: DockerImage
-        name: {{ image }}:{{ deployment }}
+        name: {{ image }}
       importPolicy:
         # Periodically query registry to synchronize tag and image metadata.
         scheduled: {{ auto_import_images }}

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -30,9 +30,9 @@
     without_redis_commander: false
     without_flower: false
     # feel free to override this in vars
-    image: "usercont/packit-service"
-    image_worker: "usercont/packit-service-worker"
-    image_fedmsg: "usercont/packit-service-fedmsg"
+    image: "usercont/packit-service:{{ deployment }}"
+    image_worker: "usercont/packit-service-worker:{{ deployment }}"
+    image_fedmsg: "usercont/packit-service-fedmsg:{{ deployment }}"
     worker_replicas: 2
     path_to_secrets: "../secrets"
     # to be used in Image streams as importPolicy:scheduled value

--- a/vars/template.yml
+++ b/vars/template.yml
@@ -51,13 +51,13 @@ without_flower: false
 # sandbox_namespace: "packit-prod-sandbox"
 
 # image to use for service and fedmsg pods
-# image: usercont/packit-service
+# image: usercont/packit-service:{{ deployment }}
 
 # image to use for worker
-# image_worker: usercont/packit-service-worker
+# image_worker: usercont/packit-service-worker:{{ deployment }}
 
 # image to use for fedora messaging consumer
-# image_fedmsg: usercont/packit-service-fedmsg
+# image_fedmsg: usercont/packit-service-fedmsg:latest
 
 # Number of worker pods to be deployed
 # worker_replicas : 2


### PR DESCRIPTION
Before the image specs for packit-service and packit-service-worker were
composed of the image name and the tag, and the later was always
`deployment`.

This made somewhat difficult to deploy the service with *:prod images
locally.

This is made much simpler if we allow providing a full spec for these
images in `vars`.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>