### PR TITLE
Separate Redis and Redis Commander deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,21 @@
-.PHONY: send-release-event deploy cleanup zuul-secrets get-certs
+.PHONY: send-release-event deploy tags cleanup zuul-secrets get-certs
 
 ANSIBLE_PYTHON := /usr/bin/python3
 CONT_HOME := /opt/app-root/src
 AP := ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=$(ANSIBLE_PYTHON)
+# "By default, Ansible runs as if --tags all had been specified."
+# https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#special-tags
+TAGS ?= all
 
 # use route when doing this on a remote openshift cluster
 send-release-event:
 	curl -d "@test_data/release_event.json" -H "Content-Type: application/json" -X POST http://$(shell oc get svc packit-service -o json | jq -r .spec.clusterIP)/webhooks/github/release
 
 deploy:
-	$(AP) playbooks/deploy.yml
+	$(AP) playbooks/deploy.yml --tags $(TAGS)
+
+tags:
+	$(AP) playbooks/deploy.yml --list-tags
 
 cleanup:
 	$(AP) playbooks/cleanup.yml

--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ once a new image is pushed/built in registry.
 
 There's also 'import-images' target in the Makefile, so `DEPLOYMENT=prod make import-images` does this for you for all images (image streams).
 
+### Partial deployments
+
+To run only the tasks related to some of the services, this way doing a
+partial deployment, you can set the `TAGS` environment variable before calling
+`make`. For example, to run only the tasks to deploy Redis and Redis
+Commander, run:
+
+```
+$ DEPLOYMENT=dev TAGS="redis,redis-commander" make deploy
+```
+
+Use `make tags` to list the currently available tags.
+
 ### Reverting to older deployment/revision/image
 
 `DeploymentConfig`s (i.e. service & service-fedmsg) can be reverted with `oc rollout undo`:

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -40,8 +40,12 @@
   tasks:
     - name: include variables
       include_vars: ../vars/{{ deployment }}.yml
+      tags:
+        - always
     - name: include extra secret vars
       include_vars: "{{ path_to_secrets }}/{{ deployment }}/extra-vars.yml"
+      tags:
+        - redis-commander
 
     - block:
         - name: get kubeconfig token
@@ -53,6 +57,8 @@
               - kubeconfig_token.stdout == api_key
             msg: "OpenShift API token defined in vars/ does not match token from your current environment."
       ignore_errors: yes
+      tags:
+        - always
 
     - name: Deploy templates (need to be processed)
       # https://docs.ansible.com/k8s_module.html
@@ -68,7 +74,6 @@
         - "{{ lookup('template', '../openshift/secret-packit-config.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/secret-sentry.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/secret-postgres.yml.j2') | from_yaml }}"
-        - "{{ lookup('template', '../openshift/secret-redis-commander.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/cmap-packit-httpd-conf.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/route.packit.yml.j2') | from_yaml }}"
         - "{{ lookup('template', '../openshift/sandbox-namespace.yml.j2') | from_yaml }}"
@@ -97,9 +102,34 @@
         api_key: "{{ api_key }}"
         verify_ssl: "{{ validate_certs }}" # 2.7 compatibility
       loop:
-        - ../openshift/redis.yml
         - ../openshift/service.yml
         - ../openshift/pg.yml
+
+    - name: Deploy redis
+      k8s:
+        namespace: "{{ project }}"
+        src: ../openshift/redis.yml
+        host: "{{ host }}"
+        api_key: "{{ api_key }}"
+        verify_ssl: "{{ validate_certs }}" # 2.7 compatibility
+        apply: yes
+      tags:
+        - redis
+
+    - name: Create redis-commander secrets
+      k8s:
+        namespace: "{{ project }}"
+        definition: "{{ item }}"
+        host: "{{ host }}"
+        api_key: "{{ api_key }}"
+        verify_ssl: "{{ validate_certs }}" # 2.7 compatibility
+        apply: yes
+      loop:
+        - "{{ lookup('template', '../openshift/secret-redis-commander.yml.j2') | from_yaml }}"
+      tags:
+        - redis-commander
+      notify:
+        - Rollout redis-commander
 
     - name: Deploy redis-commander
       k8s:
@@ -108,7 +138,11 @@
         host: "{{ host }}"
         api_key: "{{ api_key }}"
         verify_ssl: "{{ validate_certs }}" # 2.7 compatibility
+        apply: yes
       when: not without_redis_commander
+      tags:
+        - redis-commander
+      register: redis_commander
 
     - name: Deploy flower
       k8s:
@@ -130,3 +164,10 @@
 
     - name: Set up the sandbox namespace
       command: oc adm -n {{ sandbox_namespace }} policy add-role-to-user edit system:serviceaccount:{{ project }}:default
+
+  handlers:
+    - name: Rollout redis-commander
+      command: oc rollout latest dc/redis-commander
+      # Run this rollout only if the DeploymentConfig above didn't change,
+      # and so it wasn't rolled out yet.
+      when: not redis_commander.changed


### PR DESCRIPTION
This is to enable deploying Redis and/or Redis Commander on their own,
independent of the other objects in the OpenShift project.

One can use the `TAGS` env var to select tags to be run by `make
deploy`.

For example:

    $ DEPLOYMENT=DEV TAGS="redis,redis-commander" make deploy

So far only "redis" and "redis-commander" are available as tags. `make
tags` can be used to tell all the tags available.

Furthermore: update Redis and Redis Commander related tasks to use
[`apply: yes`] for resource definitions, in order to make these
definitions idempotent. (Previously removing an environment variable
from the DeploymentConfig did not result in a DeploymentConfig change
because of the default merge_type used by k8s.) This requires Ansible
2.9 to run, but it's clearer then tweaking [merge_type].

[`apply: yes`]: https://docs.ansible.com/ansible/latest/modules/k8s_module.html#parameter-apply
[merge_type]: https://docs.ansible.com/ansible/latest/modules/k8s_module.html#parameter-merge_type

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>