### PR TITLE
Always include extra secret vars

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -43,10 +43,11 @@
       include_vars: ../vars/{{ deployment }}.yml
       tags:
         - always
+
     - name: include extra secret vars
       include_vars: "{{ path_to_secrets }}/{{ deployment }}/extra-vars.yml"
       tags:
-        - redis-commander
+        - always
 
     - block:
         - name: get kubeconfig token


### PR DESCRIPTION
This task was tagged to be run for 'redis-commander' only, but extra
vars are needed by other tasks, too. So better always include them.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>