### PR TITLE
Optionally Disable Sentry

### DIFF
--- a/secrets/template/packit-service.yaml
+++ b/secrets/template/packit-service.yaml
@@ -20,7 +20,7 @@ validate_webhooks: False
 webhook_secret: <webhook_secret>
 testing_farm_secret: <testing_farm>
 
-disable_sentry: False
+disable_sentry: True
 
 command_handler: sandcastle
 command_handler_work_dir: /sandcastle

--- a/secrets/template/packit-service.yaml
+++ b/secrets/template/packit-service.yaml
@@ -20,6 +20,8 @@ validate_webhooks: False
 webhook_secret: <webhook_secret>
 testing_farm_secret: <testing_farm>
 
+disable_sentry: False
+
 command_handler: sandcastle
 command_handler_work_dir: /sandcastle
 command_handler_image_reference: docker.io/usercont/sandcastle


### PR DESCRIPTION
Will be valid only after packit-service/packit-service#561 is approved and merged.

- Adding `disable_sentry: True` to _secrets/packit-service.yaml_ disables sentry. 
- If this line is not present or `disable_sentry: False` is set then events will be sent to sentry like normal.