### PR TITLE
Set resources:limits:memory: to 80Mi and remove resources:requests:

### DIFF
--- a/haxxx/job-import-images.yml
+++ b/haxxx/job-import-images.yml
@@ -32,10 +32,7 @@ spec:
                       # name: importimager-token-gl9g9
                       key: token
               resources:
-                requests:
-                  memory: "64Mi"
-                  cpu: "100m"
                 limits:
-                  memory: "128Mi"
+                  memory: "80Mi"
                   cpu: "100m"
           restartPolicy: OnFailure

--- a/haxxx/validation/openshift/job-run-validation.yaml
+++ b/haxxx/validation/openshift/job-run-validation.yaml
@@ -55,10 +55,7 @@ spec:
                 - name: copr-config
                   mountPath: /.config
               resources:
-                requests:
-                  memory: "64Mi"
-                  cpu: "100m"
                 limits:
-                  memory: "128Mi"
+                  memory: "80Mi"
                   cpu: "100m"
           restartPolicy: OnFailure

--- a/openshift/flower.yml
+++ b/openshift/flower.yml
@@ -52,11 +52,8 @@ spec:
           ports:
             - containerPort: 5555
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "50m"
             limits:
-              memory: "128Mi"
+              memory: "80Mi"
               cpu: "100m"
   replicas: 1
   strategy:

--- a/openshift/packit-service-centosmsg.yml.j2
+++ b/openshift/packit-service-centosmsg.yml.j2
@@ -62,11 +62,8 @@ spec:
           command:
             - "listen-to-centos-messaging"
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
             limits:
-              memory: "64Mi"
+              memory: "80Mi"
               cpu: "100m"
   # https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/basic_deployment_operations.html#image-change-trigger
   triggers:

--- a/openshift/packit-service-fedmsg.yml.j2
+++ b/openshift/packit-service-fedmsg.yml.j2
@@ -71,7 +71,7 @@ spec:
             - "listen-to-fedora-messaging"
           resources:
             requests:
-              memory: "64Mi"
+              memory: "80Mi"
               cpu: "100m"
             limits:
               memory: "128Mi"

--- a/openshift/redis-commander.yml
+++ b/openshift/redis-commander.yml
@@ -57,11 +57,8 @@ spec:
           ports:
             - containerPort: 8081
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "50m"
             limits:
-              memory: "128Mi"
+              memory: "80Mi"
               cpu: "100m"
   replicas: 1
   strategy:

--- a/openshift/redis.yml
+++ b/openshift/redis.yml
@@ -45,11 +45,8 @@ spec:
             - mountPath: "/var/lib/redis/data"
               name: redis-pv
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "100m"
             limits:
-              memory: "128Mi"
+              memory: "80Mi"
               cpu: "100m"
       volumes:
         - name: redis-pv


### PR DESCRIPTION
Services which need just few dozens Mi of mem were previously set to limit 128Mi.

After setting (#88) one of them to requests:32Mi & limits:64Mi, we were getting:
`spec.containers[0].resources.requests: Invalid value: '80Mi': must be less than or equal to memory limit`

When I'm trying to set requests to 64Mi or remove it completely the problem is still there,
so I think Openshift Online is set so that requests (& limits) can't be less than 80Mi.

EDIT: I'll test this on `stg` once I resolve a bug in `ansible-playbook` which prevents me from running `make deploy`.