### PR TITLE
[playbooks/deploy.yml] push dev images with podman

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -41,6 +41,9 @@
     path_to_secrets: "../secrets"
     # to be used in Image streams as importPolicy:scheduled value
     auto_import_images: "{{(deployment != 'prod')}}"
+    # used in dev/zuul deployment to tag & push images to cluster
+    container_engine: "podman"
+    tls_verify_false: "{{ '--tls-verify=false' if container_engine == 'podman' else '' }}"
   tasks:
     - name: include variables
       include_vars: ../vars/{{ deployment }}.yml
@@ -68,13 +71,13 @@
 
     - name: Push dev images to local registry
       block:
-        - shell: docker login -u developer -p $(oc whoami -t) 172.30.1.1:5000
-        - command: docker inspect {{ image }}
-        - command: docker tag {{ image }} 172.30.1.1:5000/myproject/packit-service:dev
-        - command: docker push 172.30.1.1:5000/myproject/packit-service:dev
-        - command: docker inspect {{ image_worker }}
-        - command: docker tag {{ image_worker }} 172.30.1.1:5000/myproject/packit-worker:dev
-        - command: docker push 172.30.1.1:5000/myproject/packit-worker:dev
+        - shell: "{{ container_engine }} login -u developer -p $(oc whoami -t) 172.30.1.1:5000 {{ tls_verify_false }}"
+        - command: "{{ container_engine }} inspect {{ image }}"
+        - command: "{{ container_engine }} tag {{ image }} 172.30.1.1:5000/myproject/packit-service:dev"
+        - command: "{{ container_engine }} push 172.30.1.1:5000/myproject/packit-service:dev {{ tls_verify_false }}"
+        - command: "{{ container_engine }} inspect {{ image_worker }}"
+        - command: "{{ container_engine }} tag {{ image_worker }} 172.30.1.1:5000/myproject/packit-worker:dev"
+        - command: "{{ container_engine }} push 172.30.1.1:5000/myproject/packit-worker:dev {{ tls_verify_false }}"
       when: deployment == "dev"
 
     - name: Deploy templates

--- a/vars/template.yml
+++ b/vars/template.yml
@@ -75,3 +75,6 @@ without_dashboard: true
 
 # Path to secrets (in case you don't have it in the root of this project)
 # path_to_secrets: /secrets
+
+# used in dev/zuul deployment to tag&push images to cluster, default: "podman"
+# container_engine: "docker"


### PR DESCRIPTION
If you want to stay with docker, just put the following into `vars/dev.yml`:
```yaml
container_engine: "docker"
```

https://github.com/packit-service/packit-service/pull/669

Why?
I was wondering why when I run 'make check-inside-openshift' @ packit-service, my freshly added tests are not run - and, it's because the images are built with `podman` by default and pushed (some old images) with `docker`.