### PR TITLE
Store vars/{deployment}_template.yml 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 vars/*.yml
-!vars/template.yml
+!vars/*template.yml
+!vars/README.md
 
 .idea/
 .DS_Store
 
 secrets/prod
-secrets/dev
 secrets/stg
+secrets/dev

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## tl;dr How to deploy
 
 1. Obtain all the necessary [secrets](/secrets/README.md).
-2. in [vars](vars/) copy [vars/template.yml](vars/template.yml) to `{deployment}.yml` where `{deployment}` is one of `prod` or `stg` and fill in values
+2. in [vars](vars/) copy `{deployment}_template.yml` to `{deployment}.yml` where `{deployment}` is one of `prod`, `stg` or `dev` and fill in values
 3. `dnf install ansible origin-clients python3-openshift`
 4. `DEPLOYMENT={deployment} make deploy`
 
@@ -11,20 +11,9 @@
 
 - [playbooks](playbooks/) - Ansible playbooks.
 - [roles](roles/) - Ansible roles.
-- [vars](vars/) - Variable file(s). See section below for more info.
+- [vars](vars/) - Variable file(s). See [vars/README.md](vars/README.md).
 - [Openshift](openshift/) - Openshift resource configuration files (templates).
 - [secrets](secrets/) - secret stuff to be used from `openshift/secret-*.yml.j2`
-
-### Variable files
-
-[vars/template.yml](vars/template.yml) is a variable file template.
-
-You have to copy it to `prod.yml`, `stg.yml` or `dev.yml`
-depending on what environment you want to deploy to.
-
-The Ansible playbook then includes one of the variable files depending on the
-value of DEPLOYMENT environment variable and processes all the templates with
-variables defined in the file.
 
 ### Images
 

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -24,6 +24,8 @@
 - name: packit-service deployment
   hosts: all
   vars:
+    # feel free to override these in vars/
+    validate_certs: no
     deployment: "{{ lookup('env', 'DEPLOYMENT') }}"
     sandbox_namespace: "packit-{{ deployment }}-sandbox"
     without_fedmsg: false
@@ -31,7 +33,6 @@
     without_redis_commander: false
     without_flower: false
     without_dashboard: true # deploy w/o dashboard by default
-    # feel free to override this in vars
     image: "docker.io/usercont/packit-service:{{ deployment }}"
     image_worker: "docker.io/usercont/packit-service-worker:{{ deployment }}"
     image_fedmsg: "docker.io/usercont/packit-service-fedmsg:{{ deployment }}"

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -28,11 +28,11 @@
     validate_certs: no
     deployment: "{{ lookup('env', 'DEPLOYMENT') }}"
     sandbox_namespace: "packit-{{ deployment }}-sandbox"
-    without_fedmsg: false
-    without_centosmsg: false
-    without_redis_commander: false
-    without_flower: false
-    without_dashboard: true # deploy w/o dashboard by default
+    with_fedmsg: true
+    with_centosmsg: true
+    with_redis_commander: true
+    with_flower: true
+    with_dashboard: false # deploy w/o dashboard by default
     image: "docker.io/usercont/packit-service:{{ deployment }}"
     image_worker: "docker.io/usercont/packit-service-worker:{{ deployment }}"
     image_fedmsg: "docker.io/usercont/packit-service-fedmsg:{{ deployment }}"
@@ -130,7 +130,7 @@
         host: "{{ host }}"
         api_key: "{{ api_key }}"
         validate_certs: "{{ validate_certs }}"
-      when: not without_dashboard
+      when: with_dashboard
       tags:
         - dashboard
 
@@ -168,7 +168,7 @@
         - redis-commander
       notify:
         - Rollout redis-commander
-      when: not without_redis_commander
+      when: with_redis_commander
 
     - name: Deploy redis-commander
       k8s:
@@ -178,7 +178,7 @@
         api_key: "{{ api_key }}"
         validate_certs: "{{ validate_certs }}"
         apply: yes
-      when: not without_redis_commander
+      when: with_redis_commander
       tags:
         - redis-commander
       register: redis_commander
@@ -197,7 +197,7 @@
         - flower
       notify:
         - Rollout flower
-      when: not without_flower
+      when: with_flower
 
     - name: Deploy flower
       k8s:
@@ -206,7 +206,7 @@
         host: "{{ host }}"
         api_key: "{{ api_key }}"
         validate_certs: "{{ validate_certs }}"
-      when: not without_flower
+      when: with_flower
       tags:
         - flower
       register: flower
@@ -221,7 +221,7 @@
         validate_certs: "{{ validate_certs }}"
       tags:
         - fedmsg
-      when: not without_fedmsg
+      when: with_fedmsg
 
     - name: Deploy packit-service-centosmsg
       # https://docs.ansible.com/k8s_module.html
@@ -233,7 +233,7 @@
         validate_certs: "{{ validate_certs }}"
       tags:
         - centosmsg
-      when: not without_centosmsg
+      when: with_centosmsg
 
     - name: Set up the sandbox namespace
       command: oc adm -n {{ sandbox_namespace }} policy add-role-to-user edit system:serviceaccount:{{ project }}:default

--- a/vars/README.md
+++ b/vars/README.md
@@ -1,0 +1,15 @@
+## Variable files
+
+[template.yml](./template.yml) is a general variable file template.
+
+There are also `{deployment}_template.yml` files,
+where `{deployment}` is one of `prod`, `stg` or `dev`.
+You have to copy those to `{deployment}.yml`
+depending on what environment you want to deploy to
+and fill in missing values.
+The `{deployment}.yml` files are `.gitignore`d so you can't
+push them to the git repo by mistake.
+
+The Ansible playbook then includes one of the variable files depending on the
+value of DEPLOYMENT environment variable and processes all the templates with
+variables defined in the file.

--- a/vars/dev_template.yml
+++ b/vars/dev_template.yml
@@ -1,0 +1,78 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------------------------------------
+# Variables needed by Ansible playbooks in playbooks/
+# -------------------------------------------------------------------
+
+# Openshift project/namespace name
+project: myproject
+
+# Openshift cluster url (example: https://console.pro-eu-west-1.openshift.com)
+host: https://127.0.0.1:8443
+
+# oc login <the above host value>, oc whoami -t
+# OR via Openshift web GUI: click on your login in top right corner, 'Copy Login Command', take the part after --token=
+api_key: ""
+# To work-around 'SSL: CERTIFICATE_VERIFY_FAILED'
+# validate_certs: no
+
+# if you want to deploy fedmsg, please make sure to
+# edit the queue name in secrets/*/fedora.toml
+with_fedmsg: false
+
+with_centosmsg: false
+
+with_redis_commander: false
+
+with_flower: false
+# don't deploy dashboard by default
+# with_dashboard: false
+
+# you can set the sandbox namespace name explicitly like this
+# sandbox_namespace: "packit-dev-sandbox"
+
+# image to use for service
+# image: docker.io/usercont/packit-service:{{ deployment }}
+
+# image to use for worker
+# image_worker: docker.io/usercont/packit-service-worker:{{ deployment }}
+
+# image to use for fedora messaging consumer
+# image_fedmsg: docker.io/usercont/packit-service-fedmsg:{{ deployment }}
+
+# image to use for centos messaging consumer
+# image_centosmsg: docker.io/usercont/packit-sevice-centosmsg:{{ deployment }}
+
+# image to use for dashboard
+# image_dashboard: "docker.io/usercont/packit-dashboard:{{ deployment }}"
+
+# Number of worker pods to be deployed
+# worker_replicas : 1
+
+# Path to secrets (in case you don't have it in the root of this project)
+# path_to_secrets: ../secrets
+
+# Used in dev/Zuul deployment to tag & push images to cluster.
+# It's set to "/usr/bin/podman" if there's podman installed, or to 'docker' otherwise.
+# If you still want to use docker even when podman is installed, set:
+# container_engine: "docker"

--- a/vars/prod_template.yml
+++ b/vars/prod_template.yml
@@ -1,0 +1,79 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------------------------------------
+# Variables needed by Ansible playbooks in playbooks/
+# -------------------------------------------------------------------
+
+# Openshift project/namespace name
+project: packit-prod
+
+# Openshift cluster url
+host: https://console.pro-eu-west-1.openshift.com
+
+# oc login <the above host value>, oc whoami -t
+# OR via Openshift web GUI: click on your login in top right corner, 'Copy Login Command', take the part after --token=
+api_key: ""
+# To work-around 'SSL: CERTIFICATE_VERIFY_FAILED'
+# validate_certs: no
+
+# if you want to deploy fedmsg, please make sure to
+# edit the queue name in secrets/*/fedora.toml
+# with_fedmsg: true
+
+# not yet
+with_centosmsg: false
+
+# with_redis_commander: true
+
+# with_flower: true
+
+# don't deploy dashboard by default
+# with_dashboard: false
+
+# you can set the sandbox namespace name explicitly like this
+# sandbox_namespace: "packit-prod-sandbox"
+
+# image to use for service
+# image: docker.io/usercont/packit-service:{{ deployment }}
+
+# image to use for worker
+# image_worker: docker.io/usercont/packit-service-worker:{{ deployment }}
+
+# image to use for fedora messaging consumer
+# image_fedmsg: docker.io/usercont/packit-service-fedmsg:{{ deployment }}
+
+# image to use for centos messaging consumer
+# image_centosmsg: docker.io/usercont/packit-sevice-centosmsg:{{ deployment }}
+
+# image to use for dashboard
+# image_dashboard: "docker.io/usercont/packit-dashboard:{{ deployment }}"
+
+# Number of worker pods to be deployed
+worker_replicas: 3
+# Path to secrets (in case you don't have it in the root of this project)
+# path_to_secrets: ../secrets
+
+# Used in dev/Zuul deployment to tag & push images to cluster.
+# It's set to "/usr/bin/podman" if there's podman installed, or to 'docker' otherwise.
+# If you still want to use docker even when podman is installed, set:
+# container_engine: "docker"

--- a/vars/stg_template.yml
+++ b/vars/stg_template.yml
@@ -1,0 +1,79 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------------------------------------
+# Variables needed by Ansible playbooks in playbooks/
+# -------------------------------------------------------------------
+
+# Openshift project/namespace name
+project: packit-stg
+
+# Openshift cluster url
+host: https://console.pro-eu-west-1.openshift.com
+
+# oc login <the above host value>, oc whoami -t
+# OR via Openshift web GUI: click on your login in top right corner, 'Copy Login Command', take the part after --token=
+api_key: ""
+# To work-around 'SSL: CERTIFICATE_VERIFY_FAILED'
+# validate_certs: no
+
+# if you want to deploy fedmsg, please make sure to
+# edit the queue name in secrets/*/fedora.toml
+# with_fedmsg: true
+
+# with_centosmsg: true
+
+# with_redis_commander: true
+
+# with_flower: true
+
+# don't deploy dashboard by default
+# with_dashboard: false
+
+# you can set the sandbox namespace name explicitly like this
+# sandbox_namespace: "packit-stg-sandbox"
+
+# image to use for service
+# image: docker.io/usercont/packit-service:{{ deployment }}
+
+# image to use for worker
+# image_worker: docker.io/usercont/packit-service-worker:{{ deployment }}
+
+# image to use for fedora messaging consumer
+# image_fedmsg: docker.io/usercont/packit-service-fedmsg:{{ deployment }}
+
+# image to use for centos messaging consumer
+# image_centosmsg: docker.io/usercont/packit-sevice-centosmsg:{{ deployment }}
+
+# image to use for dashboard
+# image_dashboard: "docker.io/usercont/packit-dashboard:{{ deployment }}"
+
+# Number of worker pods to be deployed
+# worker_replicas : 1
+
+# Path to secrets (in case you don't have it in the root of this project)
+# path_to_secrets: ../secrets
+
+# Used in dev/Zuul deployment to tag & push images to cluster.
+# It's set to "/usr/bin/podman" if there's podman installed, or to 'docker' otherwise.
+# If you still want to use docker even when podman is installed, set:
+# container_engine: "docker"

--- a/vars/template.yml
+++ b/vars/template.yml
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Don't modify this file. Copy it to e.g. dev.yml or prod.yml and modify that one.
-
 # -------------------------------------------------------------------
 # Variables needed by Ansible playbooks in playbooks/
 # -------------------------------------------------------------------
@@ -35,48 +33,47 @@ host: https://your-openshift-cluster-url
 # oc login <the above host value>, oc whoami -t
 # OR via Openshift web GUI: click on your login in top right corner, 'Copy Login Command', take the part after --token=
 api_key: ""
-
 # To work-around 'SSL: CERTIFICATE_VERIFY_FAILED'
-validate_certs: no
+# validate_certs: no
 
-# don't deploy fedmsg by default
 # if you want to deploy fedmsg, please make sure to
 # edit the queue name in secrets/*/fedora.toml
-without_fedmsg: true
+# without_fedmsg: false
 
-# don't deploy redis-commander by default
-without_redis_commander: true
+# without_centosmsg: false
 
-# don't deploy centosmsg dc; good for local testing
-without_centosmsg: true
+# without_redis_commander: false
 
-# don't deploy flower by default
-without_flower: true
+# without_flower: false
 
 # don't deploy dashboard by default
-without_dashboard: true
+# without_dashboard: true
+
 # you can set the sandbox namespace name explicitly like this
 # sandbox_namespace: "packit-prod-sandbox"
 
-# image to use for service and fedmsg pods
-# image: usercont/packit-service:{{ deployment }}
+# image to use for service
+# image: docker.io/usercont/packit-service:{{ deployment }}
 
 # image to use for worker
-# image_worker: usercont/packit-service-worker:{{ deployment }}
+# image_worker: docker.io/usercont/packit-service-worker:{{ deployment }}
 
 # image to use for fedora messaging consumer
-# image_fedmsg: usercont/packit-service-fedmsg:{{ deployment }}
+# image_fedmsg: docker.io/usercont/packit-service-fedmsg:{{ deployment }}
 
 # image to use for centos messaging consumer
-# image_centosmsg: usercont/packit-sevice-centosmsg:{{ deployment }}
+# image_centosmsg: docker.io/usercont/packit-sevice-centosmsg:{{ deployment }}
+
+# image to use for dashboard
+# image_dashboard: "docker.io/usercont/packit-dashboard:{{ deployment }}"
 
 # Number of worker pods to be deployed
-# worker_replicas : 2
+# worker_replicas : 1
 
 # Path to secrets (in case you don't have it in the root of this project)
-# path_to_secrets: /secrets
+# path_to_secrets: ../secrets
 
 # Used in dev/Zuul deployment to tag & push images to cluster.
-# It's set to "/usr/bin/podman" if there's podman command, or to 'docker' otherwise.
-# If you still want to use docker even when there's podman installed, set:
+# It's set to "/usr/bin/podman" if there's podman installed, or to 'docker' otherwise.
+# If you still want to use docker even when podman is installed, set:
 # container_engine: "docker"

--- a/vars/template.yml
+++ b/vars/template.yml
@@ -38,16 +38,16 @@ api_key: ""
 
 # if you want to deploy fedmsg, please make sure to
 # edit the queue name in secrets/*/fedora.toml
-# without_fedmsg: false
+# with_fedmsg: true
 
-# without_centosmsg: false
+# with_centosmsg: true
 
-# without_redis_commander: false
+# with_redis_commander: true
 
-# without_flower: false
+# with_flower: true
 
 # don't deploy dashboard by default
-# without_dashboard: true
+# with_dashboard: false
 
 # you can set the sandbox namespace name explicitly like this
 # sandbox_namespace: "packit-prod-sandbox"


### PR DESCRIPTION
In order to have shared settings for prod/stg deployment.

Previously a new team member (or someone who hasn't deployed to stg/prod yet) had to create their `{deployment}.yml` from `template.yml` while not sure what the settings should be for those deployments.

Now they can just copy for example `prod_template.yml` to `prod.yml` and only fill the token.

`{deployment}.yml` are still `.gitignore`d so they can't be pushed to git repo by mistake.