### PR TITLE
Upgrade cron job images to Fedora 32

### DIFF
--- a/cron-jobs/import-images/Dockerfile
+++ b/cron-jobs/import-images/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM fedora:32
 
 RUN dnf install -y origin-clients && \
     dnf clean all

--- a/cron-jobs/validation/Dockerfile
+++ b/cron-jobs/validation/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM fedora:32
 
 RUN dnf install -y python3-ogr python3-copr python3-pip && dnf clean all
 


### PR DESCRIPTION
Both were rebuilt and pushed to Docker Hub.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>