### PR TITLE
Move rebuilding of base image from Mon night to Tue night

### DIFF
--- a/.github/workflows/base-image-rebuild.yml
+++ b/.github/workflows/base-image-rebuild.yml
@@ -1,8 +1,8 @@
 name: Rebuild & push base image
 on:
   schedule:
-    # At 00:00 on Monday.
-    - cron: "0 0 * * 1"
+    # At 00:00 on Tuesday.
+    - cron: "0 0 * * 2"
   push:
     branches:
       - main


### PR DESCRIPTION
After 25c261b we build stable images on Mon (instead of Fri).
Let's rebuild base image after it (not before) so that we're not surprised.