### PR TITLE
Delete redundant `/` in dockerfile path

### DIFF
--- a/.github/workflows/build-and-push-cronjob-image.yaml
+++ b/.github/workflows/build-and-push-cronjob-image.yaml
@@ -43,7 +43,7 @@ jobs:
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
-          dockerfiles: ${{ env.path }}/Dockerfile
+          dockerfiles: ${{ env.path }}Dockerfile
           image: ${{ matrix.image }}
           oci: true
 


### PR DESCRIPTION
In consequence of #266 
There was redundant `/` in dockerfile path which caused error. (e.g. wrong path like `cron-jobs/import-images//Dockerfile`)