### PR TITLE
Change working directory to `cron-jobs/something/`

### DIFF
--- a/.github/workflows/build-and-push-cronjob-image.yaml
+++ b/.github/workflows/build-and-push-cronjob-image.yaml
@@ -45,6 +45,7 @@ jobs:
         with:
           dockerfiles: ${{ env.path }}Dockerfile
           image: ${{ matrix.image }}
+          context: ${{ env.path }}
           oci: true
 
       - name: Push To Quay


### PR DESCRIPTION
Buildah was searching files in `.` directory by default for the build context. Correctly, it should be `cron-jobs/something/`.