### PR TITLE
Do not filter manually relevant directories

### DIFF
--- a/.github/workflows/build-and-push-cronjob-image.yaml
+++ b/.github/workflows/build-and-push-cronjob-image.yaml
@@ -31,13 +31,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get changed files in a push
-        shell: bash
-        run: |
-          changed_files=$(git diff --name-only ${{ github.event.before }}..${{ github.event.after }} | tr '\n' ' ')
-          echo "::set-output name=changed_files::${changed_files}"
-        id: changed_files
-
       - name: Add short SHA to the list of tags
         shell: bash
         run: |
@@ -45,8 +38,6 @@ jobs:
         id: calculate-tags
 
       - name: Build Image
-        # To build only relevant images
-        if: contains(steps.changed_files.outputs.changed_files, env.path)
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
@@ -57,8 +48,6 @@ jobs:
           tags: ${{ steps.calculate-tags.outputs.tags }}
 
       - name: Push To Quay
-        # To push only relevant images
-        if: contains(steps.changed_files.outputs.changed_files, env.path)
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}


### PR DESCRIPTION
Use paths directive instead: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths