### PR TITLE
Define path_to_secrets in check.yml as well

### DIFF
--- a/playbooks/check.yml
+++ b/playbooks/check.yml
@@ -7,6 +7,7 @@
   vars:
     service: "{{ lookup('env', 'SERVICE') | default('packit', True) }}"
     deployment: "{{ lookup('env', 'DEPLOYMENT') }}"
+    path_to_secrets: "{{ project_dir }}/secrets/{{ service }}/{{ deployment }}"
   tasks:
     - include_tasks: tasks/project-dir.yml
 


### PR DESCRIPTION
It's needed in [tasks/set-facts.yml](https://github.com/packit/deployment/blob/main/playbooks/tasks/set-facts.yml#L32)

Fixes
```
2022-06-30 07:29:44.105058 | test-node | PLAYBOOK: check.yml ************************************************************
2022-06-30 07:29:44.105106 | test-node | 1 plays in playbooks/check.yml
2022-06-30 07:29:44.107874 | test-node |
2022-06-30 07:29:44.107938 | test-node | PLAY [Check a deployment] ******************************************************

...

2022-06-30 07:29:46.282973 | test-node | TASK [Set flower_secret_htpasswd path] *****************************************
2022-06-30 07:29:46.283013 | test-node | task path: /home/zuul-worker/src/github.com/packit/deployment/playbooks/tasks/set-facts.yml:30
2022-06-30 07:29:46.309343 | test-node | fatal: [localhost]: FAILED! => {}
2022-06-30 07:29:46.309414 | test-node |
2022-06-30 07:29:46.309427 | test-node | MSG:
2022-06-30 07:29:46.309435 | test-node |
2022-06-30 07:29:46.309473 | test-node | The task includes an option with an undefined variable. The error was: 'path_to_secrets' is undefined
2022-06-30 07:29:46.309482 | test-node |
2022-06-30 07:29:46.309533 | test-node | The error appears to be in '/home/zuul-worker/src/github.com/packit/deployment/playbooks/tasks/set-facts.yml': line 30, column 3, but may
2022-06-30 07:29:46.309581 | test-node | be elsewhere in the file depending on the exact syntax problem.
2022-06-30 07:29:46.309592 | test-node |
2022-06-30 07:29:46.309609 | test-node | The offending line appears to be:
2022-06-30 07:29:46.309616 | test-node |
2022-06-30 07:29:46.309627 | test-node |     - always
2022-06-30 07:29:46.309647 | test-node | - name: Set flower_secret_htpasswd path
2022-06-30 07:29:46.309656 | test-node |   ^ here
```