### PR TITLE
Tag the c9s image as latest

### DIFF
--- a/.github/workflows/base-image-rebuild.yml
+++ b/.github/workflows/base-image-rebuild.yml
@@ -22,9 +22,9 @@ jobs:
       matrix:
         include:
           - containerfile: containers/Containerfile.fedora
-            tags: "fedora latest"
+            tags: "fedora"
           - containerfile: containers/Containerfile.c9s
-            tags: "c9s"
+            tags: "c9s latest"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
All images are now based on the c9s base image, so move the latest tag as well.