### PR TITLE
Run packit CI on Python 3.15

### DIFF
--- a/secrets/packit/prod/packit-service.yaml.j2
+++ b/secrets/packit/prod/packit-service.yaml.j2
@@ -224,6 +224,7 @@ enabled_projects_for_fedora_ci:
   - https://src.fedoraproject.org/rpms/python3.12
   - https://src.fedoraproject.org/rpms/python3.13
   - https://src.fedoraproject.org/rpms/python3.14
+  - https://src.fedoraproject.org/rpms/python3.15
   - https://src.fedoraproject.org/rpms/python3.6
   - https://src.fedoraproject.org/rpms/python3.9
   - https://src.fedoraproject.org/rpms/python3-docs


### PR DESCRIPTION
Just run Python 3.15 on the CI :) No tests, no release notes needed.