### PR TITLE
Do not require flower authentication, nginx already handles it

### DIFF
--- a/openshift/flower.yml.j2
+++ b/openshift/flower.yml.j2
@@ -32,6 +32,8 @@ spec:
               value: redis://{{ redis_hostname }}:6379/0
             - name: FLOWER_PORT
               value: "5555"
+            - name: FLOWER_UNAUTHENTICATED_API
+              value: "true"
           ports:
             - containerPort: 5555
           resources:


### PR DESCRIPTION
With this change I can access the api/queues/length endpoint:
curl -u "nginx-usr:nginx-pwd" "https://workers.stg.packit.dev/api/queues/length"
otherwise I can't.