### PR TITLE
Run CI on python-roman-numerals

### DIFF
--- a/secrets/packit/prod/packit-service.yaml.j2
+++ b/secrets/packit/prod/packit-service.yaml.j2
@@ -1760,7 +1760,7 @@ enabled_projects_for_fedora_ci:
   - https://src.fedoraproject.org/rpms/python-rich-toolkit
   - https://src.fedoraproject.org/rpms/python-rjsmin
   - https://src.fedoraproject.org/rpms/python-robot-detection
-  - https://src.fedoraproject.org/rpms/python-roman-numerals-py
+  - https://src.fedoraproject.org/rpms/python-roman-numerals
   - https://src.fedoraproject.org/rpms/python-rope
   - https://src.fedoraproject.org/rpms/python-routes
   - https://src.fedoraproject.org/rpms/python-rpds-py


### PR DESCRIPTION
It's a rename of the older package with `-py` suffix, hence the entry replacement.
