### PR TITLE
Adding conditional Log Detective variables to configuration templates

### DIFF
--- a/secrets/packit/prod/packit-service.yaml.j2
+++ b/secrets/packit/prod/packit-service.yaml.j2
@@ -2375,3 +2375,8 @@ enabled_projects_for_fedora_ci:
   - https://src.fedoraproject.org/rpms/yt-dlp
   - https://src.fedoraproject.org/rpms/zathura-pdf-mupdf
   - https://src.fedoraproject.org/rpms/zeal
+
+# Log Detective interface server URL and token
+logdetective_enabled: false
+logdetective_url: {{ vault.logdetective.url }}
+logdetective_token: {{ vault.logdetective.token }}

--- a/secrets/packit/stg/packit-service.yaml.j2
+++ b/secrets/packit/stg/packit-service.yaml.j2
@@ -154,3 +154,8 @@ enabled_projects_for_fedora_ci:
   - https://src.fedoraproject.org/rpms/python-scikit-build-core
   - https://src.fedoraproject.org/rpms/python-specfile
   - https://src.fedoraproject.org/rpms/spglib
+
+# Log Detective interface server URL and token
+logdetective_enabled: false
+logdetective_url: {{ vault.logdetective.url }}
+logdetective_token: {{ vault.logdetective.token }}


### PR DESCRIPTION
I've used the same approach as utilized by other secrets. Both URL and token will be stored in bitwarden and rendered into template only if the URL is present. Log Detective interface server will always require authentication. Therefore, any configuration when URL is set, but the token is missing, is not viable.

Since removing the fields from configuration can be accomplished by just renaming, or removing, the variables in bitwarden, the fields were added to both prod and stage configuration templates.

RELEASE NOTES BEGIN

Log Detective URL and token are now conditional part of the service configuration. 

RELEASE NOTES END
