### PR TITLE
Enable Fedora CI by default in prod Packit service

### DIFF
--- a/secrets/packit/prod/packit-service.yaml.j2
+++ b/secrets/packit/prod/packit-service.yaml.j2
@@ -132,6 +132,11 @@ default_parse_time_macros:
 
 rate_limit_threshold: 200
 
+fedora_ci_run_by_default: true
+
+disabled_projects_for_fedora_ci: []
+
+# TODO: Remove enabled_projects_for_fedora_ci once the switch to default is complete
 # [WARNING] When adding enabled projects, keep in mind they should be handled by
 # »just one« instance to minimize clashing and undefined behavior, i.e., beta
 # users should decide whether they're opting in for:


### PR DESCRIPTION
This should be deployed next Monday.

Requires packit/packit-service#2996 to be deployed.