### PR TITLE
Allow github.com/rhel-lightspeed/goose to run internal TF requests

### DIFF
--- a/secrets/packit/prod/packit-service.yaml.j2
+++ b/secrets/packit/prod/packit-service.yaml.j2
@@ -65,6 +65,7 @@ enabled_projects_for_internal_tf:
   - github.com/RedHatInsights/rhc-worker-playbook
   - github.com/RedHat-SP-Security/clevis-tests
   - github.com/rhel-lightspeed/command-line-assistant
+  - github.com/rhel-lightspeed/goose
   - github.com/rhel-lightspeed/goose-proxy
   - github.com/InfrastructureServices/dnsconfd
   - github.com/rhkdump/kdump-utils

--- a/secrets/packit/stg/packit-service.yaml.j2
+++ b/secrets/packit/stg/packit-service.yaml.j2
@@ -68,6 +68,7 @@ enabled_projects_for_internal_tf:
   - github.com/RedHatInsights/rhc-worker-playbook
   - github.com/RedHat-SP-Security/clevis-tests
   - github.com/rhel-lightspeed/command-line-assistant
+  - github.com/rhel-lightspeed/goose
   - github.com/rhel-lightspeed/goose-proxy
   - github.com/InfrastructureServices/dnsconfd
   - github.com/rhkdump/kdump-utils


### PR DESCRIPTION
We need the github.com/rhel-lightspeed/goose to run internal TF requests